### PR TITLE
Use PackageInterface as type hint

### DIFF
--- a/src/InventoryModuleDeployment.php
+++ b/src/InventoryModuleDeployment.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 
 namespace Magento\InventoryComposerInstaller;
 
-use Composer\Package\Package;
+use Composer\Package\PackageInterface;
 use Composer\IO\IOInterface;
 
 class InventoryModuleDeployment
@@ -24,7 +24,7 @@ class InventoryModuleDeployment
         $this->io = $io;
     }
 
-    public function deploy(Package $package): void
+    public function deploy(PackageInterface $package): void
     {
         if ($package->getType() !== 'magento2-module') {
             return;


### PR DESCRIPTION
Method [Magento\InventoryComposerInstaller\InventoryModuleDeployment::deploy()](https://github.com/magento-engcom/inventory-composer-installer/blob/master/src/InventoryModuleDeployment.php#L27) use Composer\Package\Package type hint for $package parameter instead of use more general type (e.g. Composer\Package\PackageInterface). Sometimes it causes a fatal error during composer install command. For example when you try to use aliases because Composer\Package\AliasPackageclass is not extend from Composer\Package\Package.

### Preconditions
1. PHP 7.2.30
2. Composer 1.10.1
3. magento/inventory-composer-installer 1.1.0

### Steps to reproduce 
Use package alias:
`composer require vendort/module:"dev-feature/new as master-dev"`

### Expected result
`composer install` works :)

### Actual result

Error on first `composer install`:
```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Magento\InventoryComposerInstaller\InventoryModuleDeployment::deploy() must be an instance of Composer\Package\Package, instance of Composer\Package\AliasPackage given, called in /var/www/test/vendor/magento/inventory-composer-installer/src/Plugin.php on line 82 and defined in /var/www/test/vendor/magento/inventory-composer-installer/src/InventoryModuleDeployment.php:27
Stack trace:
#0 /var/www/test/vendor/magento/inventory-composer-installer/src/Plugin.php(82): Magento\InventoryComposerInstaller\InventoryModuleDeployment->deploy(Object(Composer\Package\AliasPackage))
#1 [internal function]: Magento\InventoryComposerInstaller\Plugin->onPackageChange(Object(Composer\Installer\PackageEvent))
#2 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Composer\Installer\PackageEvent))
#3 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(116) in /var/www/test/vendor/magento/inventory-composer-installer/src/InventoryModuleDeployment.php on line 27

Fatal error: Uncaught TypeError: Argument 1 passed to Magento\InventoryComposerInstaller\InventoryModuleDeployment::deploy() must be an instance of Composer\Package\Package, instance of Composer\Package\AliasPackage given, called in /var/www/test/vendor/magento/inventory-composer-installer/src/Plugin.php on line 82 and defined in /var/www/test/vendor/magento/inventory-composer-installer/src/InventoryModuleDeployment.php:27
Stack trace:
#0 /var/www/test/vendor/magento/inventory-composer-installer/src/Plugin.php(82): Magento\InventoryComposerInstaller\InventoryModuleDeployment->deploy(Object(Composer\Package\AliasPackage))
#1 [internal function]: Magento\InventoryComposerInstaller\Plugin->onPackageChange(Object(Composer\Installer\PackageEvent))
#2 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(164): call_user_func(Array, Object(Composer\Installer\PackageEvent))
#3 phar:///usr/local/bin/composer/src/Composer/EventDispatcher/EventDispatcher.php(116) in /var/www/test/vendor/magento/inventory-composer-installer/src/InventoryModuleDeployment.php on line 27

```